### PR TITLE
Scope Deps to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 To install the library, run the following command:
 
 ```bash
-npm install vasu-playwright-utils
+npm install vasu-playwright-utils  --save-dev
 ```
 
 ## Usage


### PR DESCRIPTION
Perhaps a more useful default for first time consumers, not to bloat prod runtime deps